### PR TITLE
feature/fixAuth.js

### DIFF
--- a/server/utils/auth.js
+++ b/server/utils/auth.js
@@ -1,4 +1,4 @@
-const config = require('../config/connection')
+const config = require('../config/config')
 const jwt = require('jsonwebtoken');
 const secret = config.SECRET;
 const expiration = '2h';


### PR DESCRIPTION
quick fix in auth.js We need the const config in server/auth.js to require('../config/config') so that our back end can reach the secret which is supposed to be stored in server/config/config.js